### PR TITLE
Make @workleap/create-project call npx correctly

### DIFF
--- a/.changeset/shy-pens-compare.md
+++ b/.changeset/shy-pens-compare.md
@@ -1,0 +1,5 @@
+---
+"@workleap/create-project": patch
+---
+
+Fix how foundry is called from create-project

--- a/packages/create-project/src/generateProject.ts
+++ b/packages/create-project/src/generateProject.ts
@@ -16,17 +16,17 @@ export async function generateProject(templateId: TemplateId, outputDirectory: s
     switch (templateId) {
         case "host-application":
             commandName = "generate-host-application";
-            args.push("--package-scope", packageScope!);
+            args.push("--package-scope", `"${packageScope!}"`);
             break;
         case "remote-module":
             commandName = "generate-remote-module";
-            args.push("--host-scope", hostScope!);
-            args.push("--package-name", packageName!);
+            args.push("--host-scope", `"${hostScope!}"`);
+            args.push("--package-name", `"${packageName!}"`);
             break;
         case "static-module":
             commandName = "generate-static-module";
-            args.push("--host-scope", hostScope!);
-            args.push("--package-name", packageName!);
+            args.push("--host-scope", `"${hostScope!}"`);
+            args.push("--package-name", `"${packageName!}"`);
             break;
     }
 

--- a/packages/create-project/src/generateProject.ts
+++ b/packages/create-project/src/generateProject.ts
@@ -30,7 +30,7 @@ export async function generateProject(templateId: TemplateId, outputDirectory: s
             break;
     }
 
-    const childProcess = child_process.exec(`npx @workleap/foundry ${commandName} ${args.join(" ")}`);
+    const childProcess = child_process.exec(`npx --yes @workleap/foundry@latest ${commandName} ${args.join(" ")}`);
 
     return new Promise<number>(resolve => {
         childProcess.on("error", error => {


### PR DESCRIPTION
- Always call the latest version of `@workleap/foundry`.
- Enclose value pass to `--package-scope`, `--host-scope` and `--package-name` between `"`, because if it is called from PowerShell, the `@` is the [Splat Operator](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_splatting?view=powershell-7.3&viewFallbackFrom=powershell-6).
- Call `npx` with `--yes` otherwise it will prompt when running the first time.