### PR TITLE
hotfix/TOPS-800: Renaming gsoft-inc organization to workleap in github.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -199,7 +199,7 @@ pnpm reset
 
 We use [GitHub Actions](https://github.com/features/actions) for this repository.
 
-The configuration is in the `.github/workflows` folder and the build results available [here](https://github.com/gsoft-inc/wl-foundry-cli/actions).
+The configuration is in the `.github/workflows` folder and the build results available [here](https://github.com/workleap/wl-foundry-cli/actions).
 
 We currently have 2 builds configured:
 
@@ -215,7 +215,7 @@ This build will trigger when a commit is done in a PR to `main` or after a push 
 
 There are a few steps to add new packages to the monorepo.
 
-Before you add a new package, please read the [GSoft GitHub guidelines](https://github.com/gsoft-inc/github-guidelines#npm-package-name).
+Before you add a new package, please read the [GSoft GitHub guidelines](https://github.com/workleap/github-guidelines#npm-package-name).
 
 ### Create the package
 
@@ -229,7 +229,7 @@ pnpm init
 
 Answer the CLI questions.
 
-Once the `package.json` file is generated, please read again the [GSoft GitHub guidelines](https://github.com/gsoft-inc/github-guidelines#npm-package-name) and make sure the package name, author and license are valid.
+Once the `package.json` file is generated, please read again the [GSoft GitHub guidelines](https://github.com/workleap/github-guidelines#npm-package-name) and make sure the package name, author and license are valid.
 
 Don't forget to add the [npm scope](https://docs.npmjs.com/about-scopes) `"@workleap"` before the package name. For example, if the project name is "foo", your package name should be `@workleap/foo`.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # wl-foundry-cli
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](./LICENSE)
-[![CI](https://github.com/gsoft-inc/wl-foundry-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/gsoft-inc/wl-foundry-cli/actions/workflows/ci.yml)
+[![CI](https://github.com/workleap/wl-foundry-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/workleap/wl-foundry-cli/actions/workflows/ci.yml)
 
 ## Packages
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "license": "Apache-2.0",
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/gsoft-inc/wl-foundry-cli.git"
+        "url": "git+https://github.com/workleap/wl-foundry-cli.git"
     },
     "scripts": {
         "postinstall": "pnpm -r --parallel --include-workspace-root exec pnpm dlx rimraf node_modules/.cache",

--- a/packages/create-project/CHANGELOG.md
+++ b/packages/create-project/CHANGELOG.md
@@ -4,38 +4,38 @@
 
 ### Patch Changes
 
-- [#77](https://github.com/gsoft-inc/wl-foundry-cli/pull/77) [`d732f2e`](https://github.com/gsoft-inc/wl-foundry-cli/commit/d732f2edfb9cd7e7f48a439a9bd74b7c163e0d6a) Thanks [@ofrogon](https://github.com/ofrogon)! - Update dependencies
+- [#77](https://github.com/workleap/wl-foundry-cli/pull/77) [`d732f2e`](https://github.com/workleap/wl-foundry-cli/commit/d732f2edfb9cd7e7f48a439a9bd74b7c163e0d6a) Thanks [@ofrogon](https://github.com/ofrogon)! - Update dependencies
 
-- [#79](https://github.com/gsoft-inc/wl-foundry-cli/pull/79) [`4c235fc`](https://github.com/gsoft-inc/wl-foundry-cli/commit/4c235fc870f0b8fd220572fa8e9e7329602e490b) Thanks [@ofrogon](https://github.com/ofrogon)! - Migrate project from GitHub organization
+- [#79](https://github.com/workleap/wl-foundry-cli/pull/79) [`4c235fc`](https://github.com/workleap/wl-foundry-cli/commit/4c235fc870f0b8fd220572fa8e9e7329602e490b) Thanks [@ofrogon](https://github.com/ofrogon)! - Migrate project from GitHub organization
 
 ## 0.4.0
 
 ### Minor Changes
 
-- [#71](https://github.com/gsoft-inc/wl-foundry-cli/pull/71) [`186554d`](https://github.com/gsoft-inc/wl-foundry-cli/commit/186554dfb6f8b091cd9cdc8bb43694cfe0e5f2c9) Thanks [@ofrogon](https://github.com/ofrogon)! - Add CI/CD template support and extract vscode config in it's own template
+- [#71](https://github.com/workleap/wl-foundry-cli/pull/71) [`186554d`](https://github.com/workleap/wl-foundry-cli/commit/186554dfb6f8b091cd9cdc8bb43694cfe0e5f2c9) Thanks [@ofrogon](https://github.com/ofrogon)! - Add CI/CD template support and extract vscode config in it's own template
 
 ### Patch Changes
 
-- [#73](https://github.com/gsoft-inc/wl-foundry-cli/pull/73) [`f37b240`](https://github.com/gsoft-inc/wl-foundry-cli/commit/f37b2401095fade66e54077fdea9277170060693) Thanks [@ofrogon](https://github.com/ofrogon)! - Update dependencies
+- [#73](https://github.com/workleap/wl-foundry-cli/pull/73) [`f37b240`](https://github.com/workleap/wl-foundry-cli/commit/f37b2401095fade66e54077fdea9277170060693) Thanks [@ofrogon](https://github.com/ofrogon)! - Update dependencies
 
 ## 0.3.1
 
 ### Patch Changes
 
-- [#66](https://github.com/gsoft-inc/wl-foundry-cli/pull/66) [`68cebb0`](https://github.com/gsoft-inc/wl-foundry-cli/commit/68cebb0deee7a977a7b4c05c2953e60b44bbaf24) Thanks [@ofrogon](https://github.com/ofrogon)! - Fix text replacement running on binaries files bug and `pnpm dlx` warning bubbling up to create-workleap level
+- [#66](https://github.com/workleap/wl-foundry-cli/pull/66) [`68cebb0`](https://github.com/workleap/wl-foundry-cli/commit/68cebb0deee7a977a7b4c05c2953e60b44bbaf24) Thanks [@ofrogon](https://github.com/ofrogon)! - Fix text replacement running on binaries files bug and `pnpm dlx` warning bubbling up to create-workleap level
 
 ## 0.3.0
 
 ### Minor Changes
 
-- [#27](https://github.com/gsoft-inc/wl-foundry-cli/pull/27) [`e981203`](https://github.com/gsoft-inc/wl-foundry-cli/commit/e9812035e3be3dddda6c47eecdc32927b84e3688) Thanks [@ofrogon](https://github.com/ofrogon)! - New "web-application" template support
+- [#27](https://github.com/workleap/wl-foundry-cli/pull/27) [`e981203`](https://github.com/workleap/wl-foundry-cli/commit/e9812035e3be3dddda6c47eecdc32927b84e3688) Thanks [@ofrogon](https://github.com/ofrogon)! - New "web-application" template support
 
 ## 0.2.0
 
 ### Minor Changes
 
-- [#21](https://github.com/gsoft-inc/wl-foundry-cli/pull/21) [`ced86fb`](https://github.com/gsoft-inc/wl-foundry-cli/commit/ced86fbdd1c2b4057b7c03e63ea0f27bfcd58f97) Thanks [@ofrogon](https://github.com/ofrogon)! - Add new PackageName option
+- [#21](https://github.com/workleap/wl-foundry-cli/pull/21) [`ced86fb`](https://github.com/workleap/wl-foundry-cli/commit/ced86fbdd1c2b4057b7c03e63ea0f27bfcd58f97) Thanks [@ofrogon](https://github.com/ofrogon)! - Add new PackageName option
 
 ### Patch Changes
 
-- [#26](https://github.com/gsoft-inc/wl-foundry-cli/pull/26) [`7462001`](https://github.com/gsoft-inc/wl-foundry-cli/commit/746200136c6850318abdc374cd9d75540f3ade2d) Thanks [@ofrogon](https://github.com/ofrogon)! - Fix how foundry is called from create-project
+- [#26](https://github.com/workleap/wl-foundry-cli/pull/26) [`7462001`](https://github.com/workleap/wl-foundry-cli/commit/746200136c6850318abdc374cd9d75540f3ade2d) Thanks [@ofrogon](https://github.com/ofrogon)! - Fix how foundry is called from create-project

--- a/packages/create-project/package.json
+++ b/packages/create-project/package.json
@@ -6,7 +6,7 @@
     "license": "Apache-2.0",
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/gsoft-inc/wl-foundry-cli.git",
+        "url": "git+https://github.com/workleap/wl-foundry-cli.git",
         "directory": "packages/create-project"
     },
     "publishConfig": {

--- a/packages/foundry/CHANGELOG.md
+++ b/packages/foundry/CHANGELOG.md
@@ -4,40 +4,40 @@
 
 ### Patch Changes
 
-- [#77](https://github.com/gsoft-inc/wl-foundry-cli/pull/77) [`d732f2e`](https://github.com/gsoft-inc/wl-foundry-cli/commit/d732f2edfb9cd7e7f48a439a9bd74b7c163e0d6a) Thanks [@ofrogon](https://github.com/ofrogon)! - Update dependencies
+- [#77](https://github.com/workleap/wl-foundry-cli/pull/77) [`d732f2e`](https://github.com/workleap/wl-foundry-cli/commit/d732f2edfb9cd7e7f48a439a9bd74b7c163e0d6a) Thanks [@ofrogon](https://github.com/ofrogon)! - Update dependencies
 
-- [#79](https://github.com/gsoft-inc/wl-foundry-cli/pull/79) [`4c235fc`](https://github.com/gsoft-inc/wl-foundry-cli/commit/4c235fc870f0b8fd220572fa8e9e7329602e490b) Thanks [@ofrogon](https://github.com/ofrogon)! - Migrate project from GitHub organization
+- [#79](https://github.com/workleap/wl-foundry-cli/pull/79) [`4c235fc`](https://github.com/workleap/wl-foundry-cli/commit/4c235fc870f0b8fd220572fa8e9e7329602e490b) Thanks [@ofrogon](https://github.com/ofrogon)! - Migrate project from GitHub organization
 
 ## 0.5.0
 
 ### Minor Changes
 
-- [#71](https://github.com/gsoft-inc/wl-foundry-cli/pull/71) [`186554d`](https://github.com/gsoft-inc/wl-foundry-cli/commit/186554dfb6f8b091cd9cdc8bb43694cfe0e5f2c9) Thanks [@ofrogon](https://github.com/ofrogon)! - Add CI/CD template support and extract vscode config in it's own template
+- [#71](https://github.com/workleap/wl-foundry-cli/pull/71) [`186554d`](https://github.com/workleap/wl-foundry-cli/commit/186554dfb6f8b091cd9cdc8bb43694cfe0e5f2c9) Thanks [@ofrogon](https://github.com/ofrogon)! - Add CI/CD template support and extract vscode config in it's own template
 
 ### Patch Changes
 
-- [#73](https://github.com/gsoft-inc/wl-foundry-cli/pull/73) [`f37b240`](https://github.com/gsoft-inc/wl-foundry-cli/commit/f37b2401095fade66e54077fdea9277170060693) Thanks [@ofrogon](https://github.com/ofrogon)! - Update dependencies
+- [#73](https://github.com/workleap/wl-foundry-cli/pull/73) [`f37b240`](https://github.com/workleap/wl-foundry-cli/commit/f37b2401095fade66e54077fdea9277170060693) Thanks [@ofrogon](https://github.com/ofrogon)! - Update dependencies
 
 ## 0.4.1
 
 ### Patch Changes
 
-- [#66](https://github.com/gsoft-inc/wl-foundry-cli/pull/66) [`68cebb0`](https://github.com/gsoft-inc/wl-foundry-cli/commit/68cebb0deee7a977a7b4c05c2953e60b44bbaf24) Thanks [@ofrogon](https://github.com/ofrogon)! - Fix text replacement running on binaries files bug and `pnpm dlx` warning bubbling up to create-workleap level
+- [#66](https://github.com/workleap/wl-foundry-cli/pull/66) [`68cebb0`](https://github.com/workleap/wl-foundry-cli/commit/68cebb0deee7a977a7b4c05c2953e60b44bbaf24) Thanks [@ofrogon](https://github.com/ofrogon)! - Fix text replacement running on binaries files bug and `pnpm dlx` warning bubbling up to create-workleap level
 
 ## 0.4.0
 
 ### Minor Changes
 
-- [#42](https://github.com/gsoft-inc/wl-foundry-cli/pull/42) [`926e139`](https://github.com/gsoft-inc/wl-foundry-cli/commit/926e139ef26cb0675a42da2a2a3b5b72622a972d) Thanks [@ofrogon](https://github.com/ofrogon)! - Add new step to update the dependencies of templates
+- [#42](https://github.com/workleap/wl-foundry-cli/pull/42) [`926e139`](https://github.com/workleap/wl-foundry-cli/commit/926e139ef26cb0675a42da2a2a3b5b72622a972d) Thanks [@ofrogon](https://github.com/ofrogon)! - Add new step to update the dependencies of templates
 
 ## 0.3.0
 
 ### Minor Changes
 
-- [#27](https://github.com/gsoft-inc/wl-foundry-cli/pull/27) [`e981203`](https://github.com/gsoft-inc/wl-foundry-cli/commit/e9812035e3be3dddda6c47eecdc32927b84e3688) Thanks [@ofrogon](https://github.com/ofrogon)! - New "web-application" template support
+- [#27](https://github.com/workleap/wl-foundry-cli/pull/27) [`e981203`](https://github.com/workleap/wl-foundry-cli/commit/e9812035e3be3dddda6c47eecdc32927b84e3688) Thanks [@ofrogon](https://github.com/ofrogon)! - New "web-application" template support
 
 ## 0.2.0
 
 ### Minor Changes
 
-- [#21](https://github.com/gsoft-inc/wl-foundry-cli/pull/21) [`ced86fb`](https://github.com/gsoft-inc/wl-foundry-cli/commit/ced86fbdd1c2b4057b7c03e63ea0f27bfcd58f97) Thanks [@ofrogon](https://github.com/ofrogon)! - Add new PackageName option
+- [#21](https://github.com/workleap/wl-foundry-cli/pull/21) [`ced86fb`](https://github.com/workleap/wl-foundry-cli/commit/ced86fbdd1c2b4057b7c03e63ea0f27bfcd58f97) Thanks [@ofrogon](https://github.com/ofrogon)! - Add new PackageName option

--- a/packages/foundry/README.md
+++ b/packages/foundry/README.md
@@ -25,7 +25,7 @@ Commands:
 
 ### generate-host-application
 
-Use the [host-application](https://github.com/gsoft-inc/wl-foundry-cli/tree/main/templates/host-application) template as a base to customize with these options:
+Use the [host-application](https://github.com/workleap/wl-foundry-cli/tree/main/templates/host-application) template as a base to customize with these options:
 
 | option                   | description                  | required |
 |--------------------------|------------------------------|----------|
@@ -35,7 +35,7 @@ Use the [host-application](https://github.com/gsoft-inc/wl-foundry-cli/tree/main
 
 ### generate-remote-module
 
-Use the [remote-module](https://github.com/gsoft-inc/wl-foundry-cli/tree/main/templates/remote-module) template as a base to customize with these options:
+Use the [remote-module](https://github.com/workleap/wl-foundry-cli/tree/main/templates/remote-module) template as a base to customize with these options:
 
 | option                  | description                  | required |
 |-------------------------|------------------------------|----------|
@@ -46,7 +46,7 @@ Use the [remote-module](https://github.com/gsoft-inc/wl-foundry-cli/tree/main/te
 
 ### generate-static-module
 
-Use the [static-module](https://github.com/gsoft-inc/wl-foundry-cli/tree/main/templates/static-module) template as a base to customize with these options:
+Use the [static-module](https://github.com/workleap/wl-foundry-cli/tree/main/templates/static-module) template as a base to customize with these options:
 
 | option                  | description                  | required |
 |-------------------------|------------------------------|----------|
@@ -57,7 +57,7 @@ Use the [static-module](https://github.com/gsoft-inc/wl-foundry-cli/tree/main/te
 
 ### generate-web-application
 
-Use the [web-application](https://github.com/gsoft-inc/wl-foundry-cli/tree/main/templates/web-application) template as a base to customize with these options:
+Use the [web-application](https://github.com/workleap/wl-foundry-cli/tree/main/templates/web-application) template as a base to customize with these options:
 
 | option                  | description                                         | required |
 |-------------------------|-----------------------------------------------------|----------|

--- a/packages/foundry/package.json
+++ b/packages/foundry/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/gsoft-inc/wl-foundry-cli.git",
+        "url": "git+https://github.com/workleap/wl-foundry-cli.git",
         "directory": "packages/foundry"
     },
     "publishConfig": {

--- a/templates/typescript-library/README.md
+++ b/templates/typescript-library/README.md
@@ -45,7 +45,7 @@ pnpm lint
 ```
 
 ---
-Build with [wl-foundry-cli](https://github.com/gsoft-inc/wl-foundry-cli) from [web-application template](https://github.com/gsoft-inc/wl-foundry-cli/tree/main/templates/web-application) 🚀
+Build with [wl-foundry-cli](https://github.com/workleap/wl-foundry-cli) from [web-application template](https://github.com/workleap/wl-foundry-cli/tree/main/templates/web-application) 🚀
 
 ## VSCode settings and extensions
 

--- a/templates/web-application/README.md
+++ b/templates/web-application/README.md
@@ -79,7 +79,7 @@ pnpm analyze
 ```
 
 ---
-Build with [wl-foundry-cli](https://github.com/gsoft-inc/wl-foundry-cli) from [web-application template](https://github.com/gsoft-inc/wl-foundry-cli/tree/main/templates/web-application) 🚀
+Build with [wl-foundry-cli](https://github.com/workleap/wl-foundry-cli) from [web-application template](https://github.com/workleap/wl-foundry-cli/tree/main/templates/web-application) 🚀
 
 ## VSCode settings and extensions
 


### PR DESCRIPTION
TOPS-800: Replacing gsoft-inc/wl-reusable-workflows by workleap/wl-reusable-workflows

--
Not sure why this PR has been created? Reach TechOps in our public slack channel: #techops-and-friends
Some context on the why of this PR can be found here: https://workleap.slack.com/archives/C02E9KPRQ7P/p1737385211295479 